### PR TITLE
Call new editor endpoint to search by IMEX id instead of an export en…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.hupo.psi.mi.psicquic</groupId>
     <artifactId>psicquic-view</artifactId>
     <packaging>war</packaging>
-    <version>1.6.1-SNAPSHOT</version>
+    <version>1.6.1</version>
 
     <name>PSI :: PSICQUIC View</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.hupo.psi.mi.psicquic</groupId>
     <artifactId>psicquic-view</artifactId>
     <packaging>war</packaging>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.1-SNAPSHOT</version>
 
     <name>PSI :: PSICQUIC View</name>
 

--- a/src/main/java/org/hupo/psi/mi/psicquic/view/webapp/controller/application/ImexPreviewLinkGenerator.java
+++ b/src/main/java/org/hupo/psi/mi/psicquic/view/webapp/controller/application/ImexPreviewLinkGenerator.java
@@ -13,7 +13,8 @@ import java.util.Properties;
 public class ImexPreviewLinkGenerator {
 
     private static final String PROPERTIES = "/org/hupo/psi/mi/psicquic/binarysearch/imex-preview.properties";
-    private String imexPreviewUrl;
+    private String imexPreviewSearchUrl;
+    private String imexPreviewExportUrl;
 
     private String imexId;
 
@@ -27,15 +28,24 @@ public class ImexPreviewLinkGenerator {
             throw new RuntimeException("Problems reading imex preview file from resource: " + PROPERTIES);
         }
 
-        imexPreviewUrl = props.getProperty("imex.preview.url");
+        imexPreviewSearchUrl = props.getProperty("imex.preview.search.url");
+        imexPreviewExportUrl = props.getProperty("imex.preview.export.url");
     }
 
-    public URI generateURI() {
-        return URI.create(generateURL());
+    public URI generateSearchURI() {
+        return URI.create(generateSearchURL());
     }
 
-    public String generateURL() {
-        return imexPreviewUrl.replaceAll("\\{0\\}", imexId);
+    public String generateSearchURL() {
+        return imexPreviewSearchUrl.replaceAll("\\{0\\}", imexId);
+    }
+
+    public URI generateExportURI(String format) {
+        return URI.create(generateExportURL(format));
+    }
+
+    public String generateExportURL(String format) {
+        return imexPreviewExportUrl.replaceAll("\\{0\\}", imexId).replaceAll("\\{1\\}", format);
     }
 
     public enum Format {
@@ -95,7 +105,7 @@ public class ImexPreviewLinkGenerator {
     public List<Format> getFormats() {
         List<Format> visible = Format.visible();
         for (Format format : visible) {
-            format.setUrl(generateURL());
+            format.setUrl(generateExportURL(format.toString()));
         }
         return visible;
     }

--- a/src/main/java/org/hupo/psi/mi/psicquic/view/webapp/controller/application/ImexPreviewLinkGenerator.java
+++ b/src/main/java/org/hupo/psi/mi/psicquic/view/webapp/controller/application/ImexPreviewLinkGenerator.java
@@ -30,12 +30,12 @@ public class ImexPreviewLinkGenerator {
         imexPreviewUrl = props.getProperty("imex.preview.url");
     }
 
-    public URI generateURI(String format) {
-        return URI.create(generateURL(format));
+    public URI generateURI() {
+        return URI.create(generateURL());
     }
 
-    public String generateURL(String format) {
-        return imexPreviewUrl.replaceAll("\\{0\\}", imexId).replaceAll("\\{1\\}", format);
+    public String generateURL() {
+        return imexPreviewUrl.replaceAll("\\{0\\}", imexId);
     }
 
     public enum Format {
@@ -95,7 +95,7 @@ public class ImexPreviewLinkGenerator {
     public List<Format> getFormats() {
         List<Format> visible = Format.visible();
         for (Format format : visible) {
-            format.setUrl(generateURL(format.toString()));
+            format.setUrl(generateURL());
         }
         return visible;
     }

--- a/src/main/java/org/hupo/psi/mi/psicquic/view/webapp/controller/services/ServicesController.java
+++ b/src/main/java/org/hupo/psi/mi/psicquic/view/webapp/controller/services/ServicesController.java
@@ -190,7 +190,7 @@ public class ServicesController extends BaseController implements java.io.Serial
         }
         if (userQuery.isIMEXQuery()) {
             imexPreviewLinkGenerator.setImexId(userQuery.getSearchQuery());
-            GetMethod request = new GetMethod(imexPreviewLinkGenerator.generateURL(ImexPreviewLinkGenerator.Format.tab25.toString()));
+            GetMethod request = new GetMethod(imexPreviewLinkGenerator.generateURL());
             try {
                 int response = client.executeMethod(request);
                 ServicesController.this.isValidImexPreview = response == 200;

--- a/src/main/java/org/hupo/psi/mi/psicquic/view/webapp/controller/services/ServicesController.java
+++ b/src/main/java/org/hupo/psi/mi/psicquic/view/webapp/controller/services/ServicesController.java
@@ -190,7 +190,7 @@ public class ServicesController extends BaseController implements java.io.Serial
         }
         if (userQuery.isIMEXQuery()) {
             imexPreviewLinkGenerator.setImexId(userQuery.getSearchQuery());
-            GetMethod request = new GetMethod(imexPreviewLinkGenerator.generateURL());
+            GetMethod request = new GetMethod(imexPreviewLinkGenerator.generateSearchURL());
             try {
                 int response = client.executeMethod(request);
                 ServicesController.this.isValidImexPreview = response == 200;

--- a/src/main/resources/org/hupo/psi/mi/psicquic/binarysearch/imex-preview.properties
+++ b/src/main/resources/org/hupo/psi/mi/psicquic/binarysearch/imex-preview.properties
@@ -1,1 +1,1 @@
-imex.preview.url=https://www.ebi.ac.uk/intact/editor/service/export/mi/publication-imex?imex={0}&format={1}
+imex.preview.url=https://www.ebi.ac.uk/intact/editor/service/export/mi/publication-imex/ac?imex={0}

--- a/src/main/resources/org/hupo/psi/mi/psicquic/binarysearch/imex-preview.properties
+++ b/src/main/resources/org/hupo/psi/mi/psicquic/binarysearch/imex-preview.properties
@@ -1,1 +1,2 @@
-imex.preview.url=https://www.ebi.ac.uk/intact/editor/service/export/mi/publication-imex/ac?imex={0}
+imex.preview.search.url=https://www.ebi.ac.uk/intact/editor/service/export/mi/publication-imex/ac?imex={0}
+imex.preview.export.url=https://www.ebi.ac.uk/intact/editor/service/export/mi/publication-imex?imex={0}&format={1}


### PR DESCRIPTION
Call new IntAct editor endpoint to search for curated publications by IMEX id. The new endpoint simply searches and return the publication AC, instead of actually doing an export, making it much faster then it currently is.

With the current endpoint, we're running into 500 errors when the export call takes too long and the call connection is closed by Psicquic view before the export has finished.

New editor endpoint has not been released yet, so this is still a draft until that it's done.